### PR TITLE
Add Quarto model card workflow

### DIFF
--- a/.github/workflows/quarto-model-card.yml
+++ b/.github/workflows/quarto-model-card.yml
@@ -23,9 +23,10 @@ jobs:
           pip install -r requirements.txt jupyter
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
-      - name: Install TinyTeX
-        run: |
-          quarto install tinytex --no-prompt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tinytex: true
       - name: Render model card
         run: |
           quarto render model_card_template.qmd --output-dir _output

--- a/.github/workflows/quarto-model-card.yml
+++ b/.github/workflows/quarto-model-card.yml
@@ -13,6 +13,14 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt jupyter
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
       - name: Render model card

--- a/.github/workflows/quarto-model-card.yml
+++ b/.github/workflows/quarto-model-card.yml
@@ -1,0 +1,25 @@
+name: Quarto Model Card
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.qmd'
+      - '.github/workflows/quarto-model-card.yml'
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+      - name: Render model card
+        run: |
+          quarto render model_card_template.qmd --output-dir _output
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: model-card-html
+          path: _output/

--- a/.github/workflows/quarto-model-card.yml
+++ b/.github/workflows/quarto-model-card.yml
@@ -23,6 +23,9 @@ jobs:
           pip install -r requirements.txt jupyter
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+      - name: Install TinyTeX
+        run: |
+          quarto install tinytex --no-prompt
       - name: Render model card
         run: |
           quarto render model_card_template.qmd --output-dir _output

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ A modern, clean template for creating model cards using Quarto & Python. This te
 
 2. **Add your model details:**
    - Copy `model_card_template.qmd` to a new file (e.g., `my_model_card.qmd`).
-   - Replace the placeholders (e.g., `{{< model_name >}}`) with your model's information.
+   - Edit the values under the `params:` section at the top of the file to add your model name, overview, metrics, and usage notes.
    - Required images:
      - `nmfs-opensci-logo3.png` - NMFS OpenSci logo (download from [NOAA-NMFS-Brand-Resources](https://github.com/nmfs-opensci/NOAA-NMFS-Brand-Resources/blob/main/logos/nmfs-opensci-logo3.png))
      - `example_detection.png` - An example of your model's detection/output
      - `example_PR_curve.png` - Your model's precision-recall curve
-   - Update the placeholders `{{< metric_map >}}`, `{{< metric_precision >}}`, and `{{< metric_recall >}}` with your own numbers.
+   - The `metric_map`, `metric_precision`, and `metric_recall` parameters populate the dashboard-style value boxes.
 
 3. **Render the model card:**
    ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A modern, clean template for creating model cards using Quarto & Python. This te
 - 🔄 Automated GitHub Actions workflow for Quarto rendering
 - 📈 Support for data visualization
 - 🎯 Focus on key metrics and explanations
+- Metrics are displayed in dashboard-style value boxes using the provided CSS classes.
+
 
 ### How to Use
 
@@ -30,6 +32,7 @@ A modern, clean template for creating model cards using Quarto & Python. This te
      - `nmfs-opensci-logo3.png` - NMFS OpenSci logo (download from [NOAA-NMFS-Brand-Resources](https://github.com/nmfs-opensci/NOAA-NMFS-Brand-Resources/blob/main/logos/nmfs-opensci-logo3.png))
      - `example_detection.png` - An example of your model's detection/output
      - `example_PR_curve.png` - Your model's precision-recall curve
+   - Update the placeholders `{{< metric_map >}}`, `{{< metric_precision >}}`, and `{{< metric_recall >}}` with your own numbers.
 
 3. **Render the model card:**
    ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A modern, clean template for creating model cards using Quarto & Python. This te
 - 📊 Clean, modern single-page layout
 - 🎨 NOAA/NMFS branded design with official colors
 - 📱 Responsive column layout
-- 🔄 Automated GitHub Actions workflow
+- 🎨 Quarto template with NOAA colors
+- 🔄 Automated GitHub Actions workflow for Quarto rendering
 - 📈 Support for data visualization
 - 🎯 Focus on key metrics and explanations
 
@@ -39,6 +40,10 @@ A modern, clean template for creating model cards using Quarto & Python. This te
    quarto render my_model_card.qmd --to pdf
    ```
    The output will be in the `_output` folder.
+
+4. **Automate with GitHub Actions:**
+   - A workflow in `.github/workflows/quarto-model-card.yml` renders the Quarto template whenever `.qmd` files change or the workflow is manually run.
+   - The rendered model card (HTML/PDF) is uploaded as a workflow artifact for easy download.
 
 ### Template Features
 - Clean, one-page layout

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ A modern, clean template for creating model cards using Quarto & Python. This te
      ```bash
      pip install -r requirements.txt jupyter
      ```
-   - For PDF output:
-     ```powershell
-     quarto install tinytex
+   - For PDF output (TinyTeX provides a minimal TeX distribution):
+     ```bash
+     quarto install tinytex --no-prompt
      ```
 
 2. **Add your model details:**
@@ -50,7 +50,7 @@ A modern, clean template for creating model cards using Quarto & Python. This te
 
 4. **Automate with GitHub Actions:**
    - A workflow in `.github/workflows/quarto-model-card.yml` renders the Quarto template whenever `.qmd` files change or the workflow is manually run.
-   - The workflow installs dependencies (including Jupyter) and then renders the template.
+   - The workflow installs dependencies (including Jupyter) and TinyTeX, then renders the template.
    - The rendered model card (HTML/PDF) is uploaded as a workflow artifact for easy download.
 
 ### Template Features

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A modern, clean template for creating model cards using Quarto & Python. This te
      ```bash
      quarto install tinytex --no-prompt
      ```
+     The GitHub Actions workflow also installs TinyTeX automatically by setting `tinytex: true` in the Quarto setup step.
 
 2. **Add your model details:**
    - Copy `model_card_template.qmd` to a new file (e.g., `my_model_card.qmd`).
@@ -50,7 +51,7 @@ A modern, clean template for creating model cards using Quarto & Python. This te
 
 4. **Automate with GitHub Actions:**
    - A workflow in `.github/workflows/quarto-model-card.yml` renders the Quarto template whenever `.qmd` files change or the workflow is manually run.
-   - The workflow installs dependencies (including Jupyter) and TinyTeX, then renders the template.
+   - The workflow installs dependencies (including Jupyter) and uses the Quarto setup action with `tinytex: true` to install TinyTeX automatically.
    - The rendered model card (HTML/PDF) is uploaded as a workflow artifact for easy download.
 
 ### Template Features

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ A modern, clean template for creating model cards using Quarto & Python. This te
 
 1. **Install Requirements:**
    - Download and install Quarto from https://quarto.org/docs/get-started/
+   - Install Python dependencies:
+     ```bash
+     pip install -r requirements.txt jupyter
+     ```
    - For PDF output:
      ```powershell
      quarto install tinytex
@@ -46,6 +50,7 @@ A modern, clean template for creating model cards using Quarto & Python. This te
 
 4. **Automate with GitHub Actions:**
    - A workflow in `.github/workflows/quarto-model-card.yml` renders the Quarto template whenever `.qmd` files change or the workflow is manually run.
+   - The workflow installs dependencies (including Jupyter) and then renders the template.
    - The rendered model card (HTML/PDF) is uploaded as a workflow artifact for easy download.
 
 ### Template Features

--- a/assets/model-card.css
+++ b/assets/model-card.css
@@ -14,3 +14,31 @@ footer {
   margin-top: 2em;
   color: #1a1a1a;
 }
+
+/* Dashboard style boxes for key metrics */
+.metrics {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.metric-box {
+  background-color: #005CB9;
+  color: #ffffff;
+  border-radius: 0.5rem;
+  padding: 0.8rem 1rem;
+  flex: 1 1 120px;
+  text-align: center;
+}
+
+.metric-value {
+  font-size: 1.6rem;
+  font-weight: bold;
+}
+
+.metric-label {
+  font-size: 0.9rem;
+  margin-top: 0.2rem;
+  opacity: 0.9;
+}

--- a/assets/model-card.css
+++ b/assets/model-card.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, sans-serif;
+  color: #1a1a1a;
+  line-height: 1.4;
+}
+
+h1, h2, h3, h4 {
+  color: #005CB9;
+}
+
+footer {
+  font-size: 0.8rem;
+  text-align: center;
+  margin-top: 2em;
+  color: #1a1a1a;
+}

--- a/model_card_template.qmd
+++ b/model_card_template.qmd
@@ -1,0 +1,27 @@
+---
+title: "{{< model_name >}}"
+format:
+  html:
+    toc: true
+    theme: cosmo
+    css: assets/model-card.css
+  pdf:
+    documentclass: article
+jupyter: python3
+---
+
+# Model Overview
+
+{{< overview >}}
+
+## Key Metrics
+
+{{< metrics >}}
+
+## Usage Guide
+
+{{< usage >}}
+
+<footer>
+Generated with the NOAA Model Card Template
+</footer>

--- a/model_card_template.qmd
+++ b/model_card_template.qmd
@@ -7,7 +7,6 @@ format:
     css: assets/model-card.css
   pdf:
     documentclass: article
-jupyter: python3
 ---
 
 # Model Overview

--- a/model_card_template.qmd
+++ b/model_card_template.qmd
@@ -16,7 +16,34 @@ jupyter: python3
 
 ## Key Metrics
 
-{{< metrics >}}
+::: {.metrics}
+::: {.metric-box}
+:::{.metric-value}
+{{< metric_map >}}
+:::
+:::{.metric-label}
+mAP50
+:::
+:::
+
+::: {.metric-box}
+:::{.metric-value}
+{{< metric_precision >}}
+:::
+:::{.metric-label}
+Precision
+:::
+:::
+
+::: {.metric-box}
+:::{.metric-value}
+{{< metric_recall >}}
+:::
+:::{.metric-label}
+Recall
+:::
+:::
+:::
 
 ## Usage Guide
 

--- a/model_card_template.qmd
+++ b/model_card_template.qmd
@@ -1,5 +1,5 @@
 ---
-title: "{{< param model_name >}}"
+title: "{{< var params.model_name >}}"
 format:
   html:
     toc: true
@@ -18,14 +18,14 @@ params:
 
 # Model Overview
 
-{{< param overview >}}
+{{< var params.overview >}}
 
 ## Key Metrics
 
 ::: {.metrics}
 ::: {.metric-box}
 :::{.metric-value}
-{{< param metric_map >}}
+{{< var params.metric_map >}}
 :::
 :::{.metric-label}
 mAP50
@@ -34,7 +34,7 @@ mAP50
 
 ::: {.metric-box}
 :::{.metric-value}
-{{< param metric_precision >}}
+{{< var params.metric_precision >}}
 :::
 :::{.metric-label}
 Precision
@@ -43,7 +43,7 @@ Precision
 
 ::: {.metric-box}
 :::{.metric-value}
-{{< param metric_recall >}}
+{{< var params.metric_recall >}}
 :::
 :::{.metric-label}
 Recall
@@ -53,7 +53,7 @@ Recall
 
 ## Usage Guide
 
-{{< param usage >}}
+{{< var params.usage >}}
 
 <footer>
 Generated with the NOAA Model Card Template

--- a/model_card_template.qmd
+++ b/model_card_template.qmd
@@ -1,5 +1,5 @@
 ---
-title: "{{< model_name >}}"
+title: "{{< param model_name >}}"
 format:
   html:
     toc: true
@@ -7,18 +7,25 @@ format:
     css: assets/model-card.css
   pdf:
     documentclass: article
+params:
+  model_name: "Model Name"
+  overview: "Add an overview of your model here."
+  metric_map: "0.0"
+  metric_precision: "0.0"
+  metric_recall: "0.0"
+  usage: "Describe how to use the model."
 ---
 
 # Model Overview
 
-{{< overview >}}
+{{< param overview >}}
 
 ## Key Metrics
 
 ::: {.metrics}
 ::: {.metric-box}
 :::{.metric-value}
-{{< metric_map >}}
+{{< param metric_map >}}
 :::
 :::{.metric-label}
 mAP50
@@ -27,7 +34,7 @@ mAP50
 
 ::: {.metric-box}
 :::{.metric-value}
-{{< metric_precision >}}
+{{< param metric_precision >}}
 :::
 :::{.metric-label}
 Precision
@@ -36,7 +43,7 @@ Precision
 
 ::: {.metric-box}
 :::{.metric-value}
-{{< metric_recall >}}
+{{< param metric_recall >}}
 :::
 :::{.metric-label}
 Recall
@@ -46,7 +53,7 @@ Recall
 
 ## Usage Guide
 
-{{< usage >}}
+{{< param usage >}}
 
 <footer>
 Generated with the NOAA Model Card Template


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to render Quarto template
- include Quarto template and simple CSS styling
- document Quarto automation in README

## Testing
- `python -m py_compile fetch_hf_model_card.py build.py`
- `python -m py_compile python/build.py python/fetch_hf_model_card.py 2>/dev/null`
- `quarto --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846418115c48324bd86cb9a0267c0cc