### PR TITLE
🎨 Palette: Enhance gallery accessibility and focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Skip Links and Focus-Within for Gallery Accessibility
+**Learning:** For card-based layouts where the primary interaction is a nested link, using `:focus-within` on the card container provides superior visual feedback for keyboard users compared to focusing the link alone. Additionally, 'Skip to Content' links must always have a matching target ID on the primary `<main>` element to be functional.
+**Action:** Always implement `:focus-within` on card components and ensure skip link targets are correctly identified in the DOM.

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -253,6 +253,32 @@
             text-decoration: underline;
         }
 
+        .skip-link {
+            position: absolute;
+            top: -100px;
+            left: 0;
+            background: #005cb9;
+            color: white;
+            padding: 12px 24px;
+            z-index: 1000;
+            text-decoration: none;
+            font-weight: bold;
+            border-bottom-right-radius: 8px;
+            transition: top 0.2s ease;
+        }
+
+        .skip-link:focus {
+            top: 0;
+        }
+
+        .model-card:focus-within {
+            transform: translateY(-4px);
+            box-shadow: 0 12px 28px rgba(0, 56, 101, 0.12);
+            border-color: #005cb9;
+            outline: 2px solid #005cb9;
+            outline-offset: 2px;
+        }
+
         @media (max-width: 768px) {
             .card-grid {
                 grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
@@ -307,6 +333,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     <div class="page">
         <header>
             <div class="header-content">
@@ -328,7 +355,7 @@
             </div>
         </header>
 
-        <main id="gallery">
+        <main id="main-content">
             
         <section class="pipeline-section" data-pipeline="image-classification">
             <h2>Image Classification</h2>
@@ -342,7 +369,7 @@
                     <span class="pipeline-badge">Image Classification</span>
                     <p class="card-description">A YOLO11m image classification model trained to classify **broad benthic cover categories (Tier-1)** in underwater reef imagery from NOAA Pacific Islands surveys. The model achieves **71.0% top-1 accu</p>
                     <p class="card-org">Organization: NMFS-OSI</p>
-                    <a href="cards/NMFS-OSI/yolo11m-cls-noaa-pacific-benthic-cover-t1.html" class="card-link">View Full Card →</a>
+                    <a href="cards/NMFS-OSI/yolo11m-cls-noaa-pacific-benthic-cover-t1.html" class="card-link" aria-label="View full card for Nmfs Osi/Yolo11M Cls Noaa Pacific Benthic Cover T1">View Full Card →</a>
                 </div>
             </div>
             </div>
@@ -360,7 +387,7 @@
                     <span class="pipeline-badge">Object Detection</span>
                     <p class="card-description">This model was trained to identify and locate **Isopora crateriformis (ICRA)** using the ultralytics YOLO11 architecture in various underwater conditions. - **Model Architecture**: YOLO11m - **Task**:</p>
                     <p class="card-org">Organization: NMFS-OSI</p>
-                    <a href="cards/NMFS-OSI/yolo11m-esa-coral-icra-detector.html" class="card-link">View Full Card →</a>
+                    <a href="cards/NMFS-OSI/yolo11m-esa-coral-icra-detector.html" class="card-link" aria-label="View full card for Nmfs Osi/Yolo11M Esa Coral Icra Detector">View Full Card →</a>
                 </div>
             </div>
             </div>
@@ -380,7 +407,7 @@
             const sections = document.querySelectorAll('.pipeline-section');
             const searchInput = document.getElementById('search');
             const pipelineFilter = document.getElementById('pipeline-filter');
-            const gallery = document.getElementById('gallery');
+            const gallery = document.getElementById('main-content');
 
             function filterCards() {
                 const query = searchInput.value.toLowerCase().trim();

--- a/python/generate_gallery.py
+++ b/python/generate_gallery.py
@@ -199,9 +199,28 @@ def _generate_empty_gallery_html() -> str:
             color: #7f8c8d;
             font-size: 0.9rem;
         }
+
+        .skip-link {
+            position: absolute;
+            top: -100px;
+            left: 0;
+            background: #005cb9;
+            color: white;
+            padding: 12px 24px;
+            z-index: 1000;
+            text-decoration: none;
+            font-weight: bold;
+            border-bottom-right-radius: 8px;
+            transition: top 0.2s ease;
+        }
+
+        .skip-link:focus {
+            top: 0;
+        }
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     <div class="page">
         <header>
             <img src="assets/optics_si_logo_v1.png" alt="Optics SI" class="logo">
@@ -209,7 +228,7 @@ def _generate_empty_gallery_html() -> str:
             <p class="subtitle">NOAA Model Card Registry</p>
         </header>
 
-        <main>
+        <main id="main-content">
             <div class="empty-message">
                 <p>📦 No model cards yet</p>
                 <p>The gallery will appear here as model cards are added to the registry.</p>
@@ -523,6 +542,32 @@ def _generate_gallery_html_content(cards: List[Dict], grouped: Dict[str, List[Di
             text-decoration: underline;
         }}
 
+        .skip-link {{
+            position: absolute;
+            top: -100px;
+            left: 0;
+            background: #005cb9;
+            color: white;
+            padding: 12px 24px;
+            z-index: 1000;
+            text-decoration: none;
+            font-weight: bold;
+            border-bottom-right-radius: 8px;
+            transition: top 0.2s ease;
+        }}
+
+        .skip-link:focus {{
+            top: 0;
+        }}
+
+        .model-card:focus-within {{
+            transform: translateY(-4px);
+            box-shadow: 0 12px 28px rgba(0, 56, 101, 0.12);
+            border-color: #005cb9;
+            outline: 2px solid #005cb9;
+            outline-offset: 2px;
+        }}
+
         @media (max-width: 768px) {{
             .card-grid {{
                 grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
@@ -577,6 +622,7 @@ def _generate_gallery_html_content(cards: List[Dict], grouped: Dict[str, List[Di
     </style>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     <div class="page">
         <header>
             <div class="header-content">
@@ -597,7 +643,7 @@ def _generate_gallery_html_content(cards: List[Dict], grouped: Dict[str, List[Di
             </div>
         </header>
 
-        <main id="gallery">
+        <main id="main-content">
             {sections_html_str}
         </main>
 
@@ -613,7 +659,7 @@ def _generate_gallery_html_content(cards: List[Dict], grouped: Dict[str, List[Di
             const sections = document.querySelectorAll('.pipeline-section');
             const searchInput = document.getElementById('search');
             const pipelineFilter = document.getElementById('pipeline-filter');
-            const gallery = document.getElementById('gallery');
+            const gallery = document.getElementById('main-content');
 
             function filterCards() {{
                 const query = searchInput.value.toLowerCase().trim();
@@ -725,7 +771,7 @@ def _generate_card_html(card: Dict) -> str:
                     <span class="pipeline-badge">{_format_pipeline_name(pipeline_type)}</span>
                     <p class="card-description">{description}</p>
                     <p class="card-org">Organization: {organization}</p>
-                    <a href="{escape_html(card_url)}" class="card-link">View Full Card →</a>
+                    <a href="{escape_html(card_url)}" class="card-link" aria-label="View full card for {model_name}">View Full Card →</a>
                 </div>
             </div>'''
 


### PR DESCRIPTION
💡 What: Added a "Skip to content" link for keyboard users, implemented `:focus-within` styles for model cards to provide clear visual feedback during tab navigation, and enhanced "View Full Card" links with descriptive `aria-label` attributes.

🎯 Why: Improves the accessibility of the model gallery for screen reader and keyboard-only users, making it easier to navigate and understand the context of interactive elements.

📸 Before/After: Model cards now highlight when their internal link is focused; a "Skip to content" link appears at the top of the page on first tab.

♿ Accessibility: Functional skip link, clear focus indicators, and descriptive ARIA labels for repetitive links.

---
*PR created automatically by Jules for task [8659318577428447494](https://jules.google.com/task/8659318577428447494) started by @MichaelAkridge-NOAA*